### PR TITLE
hapi 9.x.x updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+sudo: false
 language: node_js
-
 node_js:
   - 0.10
   - 0.12

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
-#visionary
+# visionary
 
-Views loader plugin for hapi.js. Used to configure a views engine when using the hapi
-CLI. This plugin allows configuring the views manager from the CLI manifest which is
-a plain JSON file and cannot contain called to `server.views()` or require the rendering
-engine.
+Views loader plugin for hapi.js.
 
-If you are not loading your views manager from a static JSON manifest file, you probably
-don't need this plugin and can just call `server.views()` directly from your code.
+[![Build Status](https://travis-ci.org/hapijs/visionary.svg?branch=master)](https://travis-ci.org/hapijs/visionary)
+[![Dependency Status](https://david-dm.org/hapijs/visionary.svg?style=flat)](https://david-dm.org/hapijs/visionary)
+[![Peer Dependency Status](https://david-dm.org/hapijs/visionary/peer-status.svg?style=flat)](https://david-dm.org/hapijs/visionary#info=peerDependencies)
+[![Dev Dependency Status](https://david-dm.org/hapijs/visionary/dev-status.svg?style=flat)](https://david-dm.org/hapijs/visionary#info=devDependencies)
+
+Used to configure a views engine when using
+[rejoice](https://github.com/hapijs/glue) (the hapi CLI) or
+[glue](https://github.com/hapijs/glue). This plugin allows configuring the
+views manager from a manifest which is a plain JSON file and cannot contain
+calls to `server.views()` or require the rendering engine.
+
+If you are not loading your views manager from a static JSON manifest file, you
+probably don't need this plugin. See [`vision`](https://github.com/hapijs/vision).
 
 ```json
 {
@@ -16,6 +24,7 @@ don't need this plugin and can just call `server.views()` directly from your cod
         }
     ],
     "plugins": {
+        "vision": {},
         "visionary": {
             "engines": { "html": "handlebars" },
             "path": "/where/my/template/file/are/located"
@@ -24,6 +33,7 @@ don't need this plugin and can just call `server.views()` directly from your cod
 }
 ```
 
-[![Build Status](https://secure.travis-ci.org/hapijs/visionary.png)](http://travis-ci.org/hapijs/visionary)
+Note: You need to include `vision` as a dependency in your project and define
+it in your manifest. It's used as a peer dependency in `visionary`.
 
-Lead Maintainer - [Eran Hammer](https://github.com/hueniverse)
+Lead Maintainer - [Reza Akhavan](https://github.com/jedireza)

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,29 +5,36 @@ var Hoek = require('hoek');
 
 // Declare internals
 
-var internals = {};
+var internals = {
+    after: function (options, server, next) {
+
+        Hoek.assert(options, 'Visionary missing configuration');
+        Hoek.assert(options.engines, 'Visionary configuration missing engines');
+
+        var settings = Hoek.cloneWithShallow(options, 'engines');
+        settings.engines = {};
+
+        // Process configuration
+
+        var engines = Object.keys(options.engines);
+        engines.forEach(function (engine) {
+
+            var value = options.engines[engine];
+            settings.engines[engine] = typeof value === 'string' ? require(value) : value;
+        });
+
+        // Setup manager
+
+        server.root.views(settings);
+        return next();
+    }
+};
 
 
 exports.register = function (server, options, next) {
 
-    Hoek.assert(options, 'Visionary missing configuration');
-    Hoek.assert(options.engines, 'Visionary configuration missing engines');
+    server.dependency('vision', internals.after.bind(null, options));
 
-    var settings = Hoek.cloneWithShallow(options, 'engines');
-    settings.engines = {};
-
-    // Process configuration
-
-    var engines = Object.keys(options.engines);
-    engines.forEach(function (engine) {
-
-        var value = options.engines[engine];
-        settings.engines[engine] = typeof value === 'string' ? require(value) : value;
-    });
-
-    // Setup manager
-
-    server.root.views(settings);
     return next();
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Views loader plugin for hapi.js",
   "version": "2.0.0",
   "repository": "git://github.com/hapijs/visionary",
-  "main": "index",
+  "main": "lib/index.js",
   "keywords": [
     "views",
     "plugin",
@@ -16,13 +16,15 @@
     "hoek": "2.x.x"
   },
   "peerDependencies": {
-    "hapi": ">=8.x.x"
+    "hapi": ">=9.x.x",
+    "vision": ">=2.x.x"
   },
   "devDependencies": {
     "code": "1.x.x",
-    "handlebars": "1.x.x",
-    "hapi": "8.x.x",
-    "lab": "5.x.x"
+    "handlebars": "3.x.x",
+    "hapi": "9.x.x",
+    "lab": "5.x.x",
+    "vision": "2.x.x"
   },
   "scripts": {
     "test": "make test-cov"

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 var Code = require('code');
 var Hapi = require('hapi');
 var Lab = require('lab');
+var Vision = require('vision');
 var Visionary = require('../');
 
 // Declare internals
@@ -22,14 +23,17 @@ describe('register()', function () {
 
     it('registers a views manager', function (done) {
 
-        var views = {
-            engines: { 'html': require('handlebars') },
-            path: __dirname
+        var VisionaryPlugin = {
+            register: Visionary,
+            options: {
+                engines: { 'html': require('handlebars') },
+                path: __dirname
+            }
         };
 
         var server = new Hapi.Server();
         server.connection();
-        server.register({ register: Visionary, options: views }, function (err) {
+        server.register([Vision, VisionaryPlugin], function (err) {
 
             expect(err).to.not.exist();
 
@@ -40,24 +44,30 @@ describe('register()', function () {
 
             server.route({ method: 'GET', path: '/', handler: handler });
 
-            server.inject('/', function (res) {
+            server.initialize(function () {
 
-                expect(res.result).to.equal('<div>\n    <h1>hi</h1>\n</div>\n');
-                done();
+                server.inject('/', function (res) {
+
+                    expect(res.result).to.equal('<div>\n    <h1>hi</h1>\n</div>\n');
+                    done();
+                });
             });
         });
     });
 
     it('registers a views manager (string engine)', function (done) {
 
-        var views = {
-            engines: { 'html': 'handlebars' },
-            path: __dirname
+        var VisionaryPlugin = {
+            register: Visionary,
+            options: {
+                engines: { 'html': 'handlebars' },
+                path: __dirname
+            }
         };
 
         var server = new Hapi.Server();
         server.connection();
-        server.register({ register: Visionary, options: views }, function (err) {
+        server.register([Vision, VisionaryPlugin], function (err) {
 
             expect(err).to.not.exist();
 
@@ -68,10 +78,13 @@ describe('register()', function () {
 
             server.route({ method: 'GET', path: '/', handler: handler });
 
-            server.inject('/', function (res) {
+            server.initialize(function () {
 
-                expect(res.result).to.equal('<div>\n    <h1>hi</h1>\n</div>\n');
-                done();
+                server.inject('/', function (res) {
+
+                    expect(res.result).to.equal('<div>\n    <h1>hi</h1>\n</div>\n');
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
 - Updates the `hapi` `peerDependencies` and `devDependencies` to `9.x.x`
 - ~~Adds `vision` as a dependency~~
 - ~~Registers the `vision` plugin internally~~
 - ~~Added test to mock a `vision` plugin registration failure~~
 - Added `vision` to `peerDependencies` and `devDependencies`
 - Using `server.dependency` to make sure `vision` is present before completing registration
 - Updated Readme
 - Updated `handlebars` dev dependency to `3.x.x`